### PR TITLE
Allow non-latin characters in url

### DIFF
--- a/guess-word.html
+++ b/guess-word.html
@@ -20,7 +20,7 @@
     <script>
         const params = new URLSearchParams(window.location.search)
         encoded = params.get('beseda')
-        toGuess = atob(encoded).toUpperCase()
+        toGuess = unescape(atob(encoded)).toUpperCase()
 
         //display:none; block
         function guess() {

--- a/select-word.html
+++ b/select-word.html
@@ -5,17 +5,13 @@
 </head>
 
 <body>
-
-
     <input type="text" placeholder="Enter word" autofocus onkeyup="updateShareLink(this.value)" maxlength="5">
     <a id="link"></a>
-
-
 
     <script>
         function updateShareLink(novaBeseda) {
             if (novaBeseda.length == 5) {
-                encoded = btoa(novaBeseda)
+                encoded = btoa(escape(novaBeseda))
                 const url = "guess-word.html?beseda=" + encoded;
                 const link = document.getElementById("link");
                 link.href = url
@@ -25,11 +21,6 @@
                 document.getElementById("link").innerHTML = 'Beseda mora biti dolga 5 znakov'
             }
         }
-
-
-
-
-
     </script>
 </body>
 


### PR DESCRIPTION
By default `btoa` only allows for latin characters. That means that any words containing non-english letters can't be encoded. To circumvent that I use escape function which changes the all non-latin characters into latin ones in a way that can be reversed using `unescape` function on the guessing page.